### PR TITLE
Update deployment templates

### DIFF
--- a/stable/cluster-proxy-addon/templates/cluster-proxy-addon-anp-deployment.yaml
+++ b/stable/cluster-proxy-addon/templates/cluster-proxy-addon-anp-deployment.yaml
@@ -79,7 +79,7 @@ spec:
           operator: Exists
       containers:
       - name: anp-server
-        image: {{ .Values.global.imageOverrides.clusterProxyAddOn }}
+        image: {{ .Values.global.imageOverrides.cluster_proxy_addon }}
         imagePullPolicy: {{ .Values.global.pullPolicy }}
         args:
           - "/proxy-server"
@@ -110,7 +110,7 @@ spec:
           - name: agentport
             containerPort: 9091
       - name: user-proxy
-        image: {{ .Values.global.imageOverrides.clusterProxyAddOn }}
+        image: {{ .Values.global.imageOverrides.cluster_proxy_addon }}
         imagePullPolicy: {{ .Values.global.pullPolicy }}
         args:
           - "/cluster-proxy"

--- a/stable/cluster-proxy-addon/templates/cluster-proxy-addon-anp-deployment.yaml
+++ b/stable/cluster-proxy-addon/templates/cluster-proxy-addon-anp-deployment.yaml
@@ -93,6 +93,15 @@ spec:
           - "--proxy-strategies=destHost"
           - "--uds-name=/tmp/cluster-proxy-addon-socket"
           - "--delete-existing-uds-file=true"
+        env:
+        {{- if .Values.hubconfig.proxyConfigs }}
+          - name: HTTP_PROXY
+            value: {{ .Values.hubconfig.proxyConfigs.HTTP_PROXY }}
+          - name: HTTPS_PROXY
+            value: {{ .Values.hubconfig.proxyConfigs.HTTPS_PROXY }}
+          - name: NO_PROXY
+            value: {{ .Values.hubconfig.proxyConfigs.NO_PROXY }}
+        {{- end }}
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -119,6 +128,15 @@ spec:
           - "--server-key=/tls/tls.key"
           - "--server-cert=/tls/tls.crt"
           - "--proxy-uds=/tmp/cluster-proxy-addon-socket"
+        env:
+        {{- if .Values.hubconfig.proxyConfigs }}
+          - name: HTTP_PROXY
+            value: {{ .Values.hubconfig.proxyConfigs.HTTP_PROXY }}
+          - name: HTTPS_PROXY
+            value: {{ .Values.hubconfig.proxyConfigs.HTTPS_PROXY }}
+          - name: NO_PROXY
+            value: {{ .Values.hubconfig.proxyConfigs.NO_PROXY }}
+        {{- end }}
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -139,3 +157,19 @@ spec:
         - name: ca-vol
           configMap:
             name: cluster-proxy-ca-bundle
+        {{- if .Values.hubconfig.proxyConfigs }}
+          - name: HTTP_PROXY
+            value: {{ .Values.hubconfig.proxyConfigs.HTTP_PROXY }}
+          - name: HTTPS_PROXY
+            value: {{ .Values.hubconfig.proxyConfigs.HTTPS_PROXY }}
+          - name: NO_PROXY
+            value: {{ .Values.hubconfig.proxyConfigs.NO_PROXY }}
+        {{- end }}
+      {{- if .Values.pullSecret }}
+      imagePullSecrets:
+      - name: {{ .Values.pullSecret }}
+      {{- end }}
+      {{- with .Values.hubconfig.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+      {{- end }}

--- a/stable/cluster-proxy-addon/templates/cluster-proxy-addon-controller-deployment.yaml
+++ b/stable/cluster-proxy-addon/templates/cluster-proxy-addon-controller-deployment.yaml
@@ -128,5 +128,5 @@ spec:
       {{- end }}
       {{- with .Values.hubconfig.nodeSelector }}
       nodeSelector:
-      {{ toYaml . | indent 8 }}
+{{ toYaml . | indent 8 }}
       {{- end }}

--- a/stable/cluster-proxy-addon/templates/cluster-proxy-addon-controller-deployment.yaml
+++ b/stable/cluster-proxy-addon/templates/cluster-proxy-addon-controller-deployment.yaml
@@ -79,7 +79,7 @@ spec:
           operator: Exists
       containers:
       - name: cluster-proxy
-        image: {{ .Values.global.imageOverrides.clusterProxyAddOn }}
+        image: {{ .Values.global.imageOverrides.cluster_proxy_addon }}
         imagePullPolicy: {{ .Values.global.pullPolicy }}
         args:
           - "/cluster-proxy"

--- a/stable/cluster-proxy-addon/values.yaml
+++ b/stable/cluster-proxy-addon/values.yaml
@@ -3,7 +3,7 @@ org: open-cluster-management
 global:
   pullPolicy: Always
   imageOverrides:
-    clusterProxyAddOn: ""
+    cluster_proxy_addon: ""
 
 arch:
   - amd64


### PR DESCRIPTION
The global imageOverrides map uses snake case for its keys

Signed-off-by: Jakob Gray <20209054+JakobGray@users.noreply.github.com>