### PR TITLE
Support local-test with kind cluster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # Output of the temporary files
 _output/
+.DS_STORE

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,13 @@ deploy: ensure-helm
 	--set cluster_basedomain="$(CLUSTER_BASE_DOMAIN)" 
 .PHONY: deploy
 
+deploy-local: ensure-helm
+	$(KUBECTL) get ns open-cluster-management ; if [ $$? -ne 0 ] ; then $(KUBECTL) create ns open-cluster-management ; fi
+	$(HELM) install -n open-cluster-management cluster-proxy-addon local-test/cluster-proxy-addon \
+	--set global.pullPolicy="$(IMAGE_PULL_POLICY)" \
+	--set global.imageOverrides.cluster_proxy_addon="$(IMAGE)" \
+	--set cluster_basedomain="$(CLUSTER_BASE_DOMAIN)"	
+
 clean: ensure-helm
 	$(HELM) delete -n open-cluster-management cluster-proxy-addon
 	$(KUBECTL) delete -n open-cluster-management configmaps cluster-proxy-ca-bundle

--- a/local-test/cluster-proxy-addon/Chart.yaml
+++ b/local-test/cluster-proxy-addon/Chart.yaml
@@ -1,0 +1,12 @@
+# Copyright (c) 2021 Red Hat, Inc.
+
+apiVersion: v1
+appVersion: "1.0.0"
+description:  helm chart for ACM cluster-proxy-addon
+name: cluster-proxy-addon
+version: 2.1.0
+category: "Development"
+verified: "RHACM"
+keywords:
+  - acm
+  - cluster-proxy

--- a/local-test/cluster-proxy-addon/templates/_helpers.tpl
+++ b/local-test/cluster-proxy-addon/templates/_helpers.tpl
@@ -1,0 +1,84 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "cluster-proxy-addon.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "cluster-proxy-addon.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "cluster-proxy-addon.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Define anp route host.
+*/}}
+{{- define "cluster-proxy-addon.anpPublicHost" -}}
+{{- $firstfourchars := .Values.cluster_basedomain | trunc 4 -}}
+{{- if eq $firstfourchars "apps" }}
+{{- printf "%s.%s" .Values.anp_route.name .Values.cluster_basedomain | trimSuffix "-" -}}
+{{- else }}
+{{- printf "%s.apps.%s" .Values.anp_route.name .Values.cluster_basedomain | trimSuffix "-" -}}
+{{- end }}
+{{- end -}}
+
+{{/*
+Define anp route host.
+*/}}
+{{- define "cluster-proxy-addon.anpPublicPort" -}}
+{{- print 443 -}}
+{{- end -}}
+
+{{/*
+Define user route host.
+*/}}
+{{- define "cluster-proxy-addon.userPublicHost" -}}
+{{- $firstfourchars := .Values.cluster_basedomain | trunc 4 -}}
+{{- if eq $firstfourchars "apps" }}
+{{- printf "%s.%s" .Values.user_route.name .Values.cluster_basedomain | trimSuffix "-" -}}
+{{- else }}
+{{- printf "%s.apps.%s" .Values.user_route.name .Values.cluster_basedomain | trimSuffix "-" -}}
+{{- end }}
+{{- end -}}
+
+{{/*
+Define anp service host.
+*/}}
+{{- define "cluster-proxy-addon.anpInClusterHost" -}}
+{{- print "cluster-proxy-addon-anp.open-cluster-management.svc.cluster.local" -}}
+{{- end -}}
+
+{{/*
+Define anp service port.
+*/}}
+{{- define "cluster-proxy-addon.anpInClusterPort" -}}
+{{- print 9091 -}}
+{{- end -}}
+
+{{/*
+Define user service port.
+*/}}
+{{- define "cluster-proxy-addon.userServiceNodePort" -}}
+{{- print 30007 -}}
+{{- end -}}

--- a/local-test/cluster-proxy-addon/templates/cluster-proxy-addon-anp-deployment.yaml
+++ b/local-test/cluster-proxy-addon/templates/cluster-proxy-addon-anp-deployment.yaml
@@ -1,0 +1,184 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "cluster-proxy-addon.fullname" . }}-anp-server
+  labels:
+    app: {{ template "cluster-proxy-addon.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ template "cluster-proxy-addon.name" . }}
+    chart: {{ template "cluster-proxy-addon.chart" . }}
+    component: cluster-proxy-addon-anp-server
+    helm.sh/chart: {{ template "cluster-proxy-addon.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  replicas: {{ .Values.hubconfig.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "cluster-proxy-addon.name" . }}
+      release: {{ .Release.Name }}
+      component: cluster-proxy-addon-anp-server
+  template:
+    metadata:
+      labels:
+        app: {{ template "cluster-proxy-addon.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/name: {{ template "cluster-proxy-addon.name" . }}
+        chart: {{ template "cluster-proxy-addon.chart" . }}
+        component: cluster-proxy-addon-anp-server
+        helm.sh/chart: {{ template "cluster-proxy-addon.chart" . }}
+        heritage: {{ .Release.Service }}
+        ocm-antiaffinity-selector: cluster-proxy-addon-anp-server
+        release: {{ .Release.Name }}
+    spec:
+      serviceAccountName: {{ template "cluster-proxy-addon.fullname" . }}
+      hostNetwork: false
+      hostPID: false
+      hostIPC: false
+      securityContext:
+        runAsNonRoot: true
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                {{- range .Values.arch }}
+                - {{ . }}
+                {{- end }}
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 70
+            podAffinityTerm:
+              topologyKey: topology.kubernetes.io/zone
+              labelSelector:
+                matchExpressions:
+                - key: ocm-antiaffinity-selector
+                  operator: In
+                  values:
+                  - cluster-proxy-addon-anp-server
+          - weight: 35
+            podAffinityTerm:
+              topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchExpressions:
+                - key: ocm-antiaffinity-selector
+                  operator: In
+                  values:
+                  - cluster-proxy-addon-anp-server
+      tolerations:
+        - key: dedicated
+          operator: Exists
+          effect: NoSchedule
+        - effect: NoSchedule 
+          key: node-role.kubernetes.io/infra 
+          operator: Exists
+      containers:
+      - name: anp-server
+        image: {{ .Values.global.imageOverrides.cluster_proxy_addon }}
+        imagePullPolicy: {{ .Values.global.pullPolicy }}
+        args:
+          - "/proxy-server"
+          - "--mode=http-connect"
+          - "--agent-port=9091"
+          - "--server-port=0"
+          - "--keepalive-time=30s"
+          - "--cluster-ca-cert=/ca/ca-bundle.crt"
+          - "--cluster-cert=/tls/tls.crt"
+          - "--cluster-key=/tls/tls.key"
+          - "--proxy-strategies=destHost"
+          - "--uds-name=/tmp/cluster-proxy-addon/socket"
+          - "--delete-existing-uds-file=true"
+        env:
+        {{- if .Values.hubconfig.proxyConfigs }}
+          - name: HTTP_PROXY
+            value: {{ .Values.hubconfig.proxyConfigs.HTTP_PROXY }}
+          - name: HTTPS_PROXY
+            value: {{ .Values.hubconfig.proxyConfigs.HTTPS_PROXY }}
+          - name: NO_PROXY
+            value: {{ .Values.hubconfig.proxyConfigs.NO_PROXY }}
+        {{- end }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+        volumeMounts:
+          - name: anp-tls-vol
+            mountPath: /tls
+            readOnly: true
+          - name: ca-vol
+            mountPath: /ca
+            readOnly: true
+          - name: uds-socket 
+            mountPath: /tmp/cluster-proxy-addon
+        ports:
+          - name: agentport
+            containerPort: 9091
+      - name: user-proxy
+        image: {{ .Values.global.imageOverrides.cluster_proxy_addon }}
+        imagePullPolicy: {{ .Values.global.pullPolicy }}
+        args:
+          - "/cluster-proxy"
+          - "user-server"
+          - "--server-port=9092"
+          - "--server-key=/tls/tls.key"
+          - "--server-cert=/tls/tls.crt"
+          - "--proxy-uds=/tmp/cluster-proxy-addon/socket"
+        env:
+        {{- if .Values.hubconfig.proxyConfigs }}
+          - name: HTTP_PROXY
+            value: {{ .Values.hubconfig.proxyConfigs.HTTP_PROXY }}
+          - name: HTTPS_PROXY
+            value: {{ .Values.hubconfig.proxyConfigs.HTTPS_PROXY }}
+          - name: NO_PROXY
+            value: {{ .Values.hubconfig.proxyConfigs.NO_PROXY }}
+        {{- end }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+        volumeMounts:
+          - name: user-tls-vol
+            mountPath: /tls
+            readOnly: true
+          - name: uds-socket 
+            mountPath: /tmp/cluster-proxy-addon
+        ports:
+          - name: userport
+            containerPort: 9092
+      volumes:
+        - name: uds-socket
+          emptyDir: {}
+        - name: user-tls-vol
+          secret:
+            secretName: cluster-proxy-addon-serving-cert # using same cert as anp-tls-vol, because in test env, there is no open-shift to generate tls for services
+        - name: anp-tls-vol
+          secret:
+            secretName: cluster-proxy-addon-serving-cert
+        - name: ca-vol
+          configMap:
+            name: cluster-proxy-ca-bundle
+        {{- if .Values.hubconfig.proxyConfigs }}
+          - name: HTTP_PROXY
+            value: {{ .Values.hubconfig.proxyConfigs.HTTP_PROXY }}
+          - name: HTTPS_PROXY
+            value: {{ .Values.hubconfig.proxyConfigs.HTTPS_PROXY }}
+          - name: NO_PROXY
+            value: {{ .Values.hubconfig.proxyConfigs.NO_PROXY }}
+        {{- end }}
+      {{- if .Values.pullSecret }}
+      imagePullSecrets:
+      - name: {{ .Values.pullSecret }}
+      {{- end }}
+      {{- with .Values.hubconfig.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+      {{- end }}

--- a/local-test/cluster-proxy-addon/templates/cluster-proxy-addon-anp-service.yaml
+++ b/local-test/cluster-proxy-addon/templates/cluster-proxy-addon-anp-service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "cluster-proxy-addon.name" . }}-anp
+  labels:
+    app: {{ template "cluster-proxy-addon.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ template "cluster-proxy-addon.name" . }}
+    chart: {{ template "cluster-proxy-addon.chart" . }}
+    component: cluster-proxy-addon-anp-server
+    helm.sh/chart: {{ template "cluster-proxy-addon.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  ports:
+  - name: anp-port
+    port: 9091
+  selector:
+    app: {{ template "cluster-proxy-addon.name" . }}
+    component: cluster-proxy-addon-anp-server
+    release: {{ .Release.Name }}

--- a/local-test/cluster-proxy-addon/templates/cluster-proxy-addon-clusterrole.yaml
+++ b/local-test/cluster-proxy-addon/templates/cluster-proxy-addon-clusterrole.yaml
@@ -1,0 +1,61 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Values.org }}:{{ .Release.Name }}:clusterrole
+  labels:
+    app: {{ template "cluster-proxy-addon.name" . }}
+    chart: {{ template "cluster-proxy-addon.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ template "cluster-proxy-addon.name" . }}
+    helm.sh/chart: {{ template "cluster-proxy-addon.chart" . }}
+    component: cluster-proxy-addon-clusterrole
+rules:
+# Allow cluster-proxy-addon hub controller to run with openshift library-go
+- apiGroups: [""]
+  resources: ["configmaps", "secrets"]
+  verbs: ["create", "get", "list", "watch", "delete", "update", "patch"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get"]
+- apiGroups: ["apps"]
+  resources: ["replicasets"]
+  verbs: ["get"]
+- apiGroups: ["", "events.k8s.io"]
+  resources: ["events"]
+  verbs: ["create", "patch", "update"]
+# Allow cluster-proxy-addon hub controller to run with addon-framwork
+- apiGroups: ["cluster.open-cluster-management.io"]
+  resources: ["managedclusters"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["work.open-cluster-management.io"]
+  resources: ["manifestworks"]
+  verbs: ["create", "get", "list", "watch", "update", "patch", "delete"]
+- apiGroups: ["addon.open-cluster-management.io"]
+  resources: ["managedclusteraddons"]
+  verbs: ["get", "list", "watch", "patch", "update"]
+- apiGroups: ["addon.open-cluster-management.io"]
+  resources: ["managedclusteraddons/finalizers"]
+  verbs: ["update"]
+- apiGroups: ["addon.open-cluster-management.io"]
+  resources: ["managedclusteraddons/status"]
+  verbs: ["patch", "update"]
+- apiGroups: ["certificates.k8s.io"]
+  resources: ["certificatesigningrequests"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["certificates.k8s.io"]
+  resources: ["certificatesigningrequests/approval"]
+  verbs: ["update", "patch"]
+- apiGroups: ["certificates.k8s.io"]
+  resources: ["signers"]
+  resourceNames: ["kubernetes.io/kube-apiserver-client"]
+  verbs: ["approve"]
+- apiGroups: ["certificates.k8s.io"]
+  resources: ["signers"]
+  resourceNames: ["open-cluster-management.io/cluster-proxy-signer"]
+  verbs: ["approve", "sign"]
+- apiGroups: ["certificates.k8s.io"]
+  resources: ["certificatesigningrequests/status"]
+  verbs: ["update"]

--- a/local-test/cluster-proxy-addon/templates/cluster-proxy-addon-clusterrolebinding.yaml
+++ b/local-test/cluster-proxy-addon/templates/cluster-proxy-addon-clusterrolebinding.yaml
@@ -1,0 +1,23 @@
+
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Values.org }}:{{ .Release.Name }}:clusterrolebinding
+  labels:
+    app: {{ template "cluster-proxy-addon.name" . }}
+    chart: {{ template "cluster-proxy-addon.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ template "cluster-proxy-addon.name" . }}
+    helm.sh/chart: {{ template "cluster-proxy-addon.chart" . }}
+    component: clusterrolebinding
+subjects:
+- kind: ServiceAccount
+  name: {{ template "cluster-proxy-addon.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ .Values.org }}:{{ .Release.Name }}:clusterrole
+  apiGroup: rbac.authorization.k8s.io

--- a/local-test/cluster-proxy-addon/templates/cluster-proxy-addon-controller-deployment.yaml
+++ b/local-test/cluster-proxy-addon/templates/cluster-proxy-addon-controller-deployment.yaml
@@ -1,0 +1,132 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: {{ template "cluster-proxy-addon.fullname" . }}-controller
+  labels:
+    app: {{ template "cluster-proxy-addon.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ template "cluster-proxy-addon.name" . }}
+    chart: {{ template "cluster-proxy-addon.chart" . }}
+    component: cluster-proxy-addon-controller
+    helm.sh/chart: {{ template "cluster-proxy-addon.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  replicas: {{ .Values.hubconfig.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "cluster-proxy-addon.name" . }}
+      release: {{ .Release.Name }}
+      component: cluster-proxy-addon-controller
+  template:
+    metadata:
+      labels:
+        app: {{ template "cluster-proxy-addon.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/name: {{ template "cluster-proxy-addon.name" . }}
+        chart: {{ template "cluster-proxy-addon.chart" . }}
+        component: cluster-proxy-addon-controller
+        helm.sh/chart: {{ template "cluster-proxy-addon.chart" . }}
+        heritage: {{ .Release.Service }}
+        ocm-antiaffinity-selector: cluster-proxy-addon-controller
+        release: {{ .Release.Name }}
+    spec:
+      serviceAccountName: {{ template "cluster-proxy-addon.fullname" . }}
+      hostNetwork: false
+      hostPID: false
+      hostIPC: false
+      securityContext:
+        runAsNonRoot: true
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                {{- range .Values.arch }}
+                - {{ . }}
+                {{- end }}
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 70
+            podAffinityTerm:
+              topologyKey: topology.kubernetes.io/zone
+              labelSelector:
+                matchExpressions:
+                - key: ocm-antiaffinity-selector
+                  operator: In
+                  values:
+                  - cluster-proxy-addon-controller
+          - weight: 35
+            podAffinityTerm:
+              topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchExpressions:
+                - key: ocm-antiaffinity-selector
+                  operator: In
+                  values:
+                  - cluster-proxy-addon-controller
+      tolerations:
+        - key: dedicated
+          operator: Exists
+          effect: NoSchedule
+        - effect: NoSchedule 
+          key: node-role.kubernetes.io/infra 
+          operator: Exists
+      containers:
+      - name: cluster-proxy
+        image: {{ .Values.global.imageOverrides.cluster_proxy_addon }}
+        imagePullPolicy: {{ .Values.global.pullPolicy }}
+        args:
+          - "/cluster-proxy"
+          - "controller"
+          - "--anp-public-host={{ template "cluster-proxy-addon.anpInClusterHost" . }}"
+          - "--anp-public-port={{ template "cluster-proxy-addon.anpInClusterPort" . }}"
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            scheme: HTTPS
+            port: 8443
+          initialDelaySeconds: 2
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            scheme: HTTPS
+            port: 8443
+          initialDelaySeconds: 2
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+        {{- if .Values.hubconfig.proxyConfigs }}
+          - name: HTTP_PROXY
+            value: {{ .Values.hubconfig.proxyConfigs.HTTP_PROXY }}
+          - name: HTTPS_PROXY
+            value: {{ .Values.hubconfig.proxyConfigs.HTTPS_PROXY }}
+          - name: NO_PROXY
+            value: {{ .Values.hubconfig.proxyConfigs.NO_PROXY }}
+        {{- end }}
+      {{- if .Values.pullSecret }}
+      imagePullSecrets:
+      - name: {{ .Values.pullSecret }}
+      {{- end }}
+      {{- with .Values.hubconfig.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+      {{- end }}

--- a/local-test/cluster-proxy-addon/templates/cluster-proxy-addon-serviceaccount.yaml
+++ b/local-test/cluster-proxy-addon/templates/cluster-proxy-addon-serviceaccount.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "cluster-proxy-addon.fullname" . }}
+  labels:
+    app: {{ template "cluster-proxy-addon.name" . }}
+    chart: {{ template "cluster-proxy-addon.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ template "cluster-proxy-addon.name" . }}
+    helm.sh/chart: {{ template "cluster-proxy-addon.chart" . }}
+    component: cluster-proxy-addon-serviceaccount

--- a/local-test/cluster-proxy-addon/templates/cluster-proxy-addon-user-service.yaml
+++ b/local-test/cluster-proxy-addon/templates/cluster-proxy-addon-user-service.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "cluster-proxy-addon.name" . }}-user
+  labels:
+    app: {{ template "cluster-proxy-addon.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ template "cluster-proxy-addon.name" . }}
+    chart: {{ template "cluster-proxy-addon.chart" . }}
+    component: cluster-proxy-addon-anp-server
+    helm.sh/chart: {{ template "cluster-proxy-addon.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  annotations:
+     service.alpha.openshift.io/serving-cert-secret-name: cluster-proxy-user-proxy-serving-cert
+spec:
+  type: NodePort
+  ports:
+  - name: user-port
+    port: 9092
+    nodePort: {{ template "cluster-proxy-addon.userServiceNodePort" . }}
+  selector:
+    app: {{ template "cluster-proxy-addon.name" . }}
+    component: cluster-proxy-addon-anp-server
+    release: {{ .Release.Name }}

--- a/local-test/cluster-proxy-addon/values.yaml
+++ b/local-test/cluster-proxy-addon/values.yaml
@@ -1,0 +1,26 @@
+org: open-cluster-management
+
+global:
+  pullPolicy: Always
+  imageOverrides:
+    cluster_proxy_addon: ""
+
+arch:
+  - amd64
+  - ppc64le
+  - s390x
+
+pullSecret: null
+
+hubconfig:
+  nodeSelector: null
+  replicaCount: 1
+  proxyConfigs: {}
+
+cluster_basedomain: ""
+
+anp_route:
+  name: cluster-proxy-anp
+
+user_route:
+  name: cluster-proxy-user


### PR DESCRIPTION
Signed-off-by: xuezhaojun <zxue@redhat.com>

Some differences in local-test:
1. no route
2. domain-name is the anp service's in-cluster hostname
3. user-service should be NodePort
3. user-server is using the same secret as anp-server