### PR TITLE
fix customized hub namespace name cause signer secret not find when do csr sign

### DIFF
--- a/stable/cluster-proxy-addon/templates/cluster-proxy-addon-controller-deployment.yaml
+++ b/stable/cluster-proxy-addon/templates/cluster-proxy-addon-controller-deployment.yaml
@@ -114,6 +114,10 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
         {{- if .Values.hubconfig.proxyConfigs }}
           - name: HTTP_PROXY
             value: {{ .Values.hubconfig.proxyConfigs.HTTP_PROXY }}


### PR DESCRIPTION
Signed-off-by: xuezhaojun <zxue@redhat.com>